### PR TITLE
fix returning nested array of 111b14a

### DIFF
--- a/Server/RestApi/ZipImportController.cpp
+++ b/Server/RestApi/ZipImportController.cpp
@@ -47,8 +47,7 @@ QHttpServerResponse ZipImportController::openZip(const QHttpServerRequest &reque
 
 QHttpServerResponse ZipImportController::readFoldersJson(const QHttpServerRequest &request)
 {
-    QJsonArray responseBody {QJsonArray::fromStringList(service.readFoldersJson())};
-
+    QJsonArray responseBody = QJsonArray::fromStringList(service.readFoldersJson());
     return QHttpServerResponse(responseBody, QHttpServerResponse::StatusCode::Ok);
 }
 


### PR DESCRIPTION
This problem is discovered on Linux. On Mac, the result was not nested. Problem is fixed.