### PR TITLE
Add server poc windows fixes

### DIFF
--- a/Client/main.js
+++ b/Client/main.js
@@ -34,7 +34,7 @@ const createWindow = () => {
 app.whenReady().then(() => {
   
   ipcMain.on('serverProcess:Run', () => {
-    // TODO: Does not generates path for .exe files on windows.
+    // Also works on windows without .exe extension.
     const serverPath = path.join(process.resourcesPath, "cli", "nesync");
 
     const min = 10000, max = 65535;

--- a/Server/RestApi/Services/FileStorageService.cpp
+++ b/Server/RestApi/Services/FileStorageService.cpp
@@ -212,6 +212,11 @@ bool FileStorageService::relocateFolder(const QString &symbolFolderPath, const Q
             QJsonObject parent = fsm->getFolderJsonBySymbolPath(folder[JsonKeys::Folder::ParentFolderPath].toString());
             QString path = parent[JsonKeys::Folder::UserFolderPath].toString();
             path += folder[JsonKeys::Folder::SuffixPath].toString();
+            path = QDir::toNativeSeparators(path);
+
+            if(!path.endsWith(QDir::separator()))
+                path.append(QDir::separator());
+
             folder[JsonKeys::Folder::UserFolderPath] = path;
         }
 

--- a/Server/RestApi/Services/FileStorageService.cpp
+++ b/Server/RestApi/Services/FileStorageService.cpp
@@ -36,7 +36,7 @@ bool FileStorageService::renameFolder(const QString &symbolFolderPath, QString f
     auto fsm = FileStorageManager::instance();
 
     QJsonObject parentDto = fsm->getFolderJsonBySymbolPath(symbolFolderPath, true);
-    QString oldName = parentDto[JsonKeys::Folder::SuffixPath].toString();
+    QString oldName = QDir::toNativeSeparators(parentDto[JsonKeys::Folder::SuffixPath].toString());
     QString newUserPath = parentDto[JsonKeys::Folder::UserFolderPath].toString().split(oldName).first();
     newUserPath += folderName;
     newUserPath = QDir::toNativeSeparators(newUserPath);

--- a/Server/RestApi/Services/FileSystemMonitorService.cpp
+++ b/Server/RestApi/Services/FileSystemMonitorService.cpp
@@ -216,6 +216,8 @@ QJsonObject FileSystemMonitorService::generateFilesObject(QStringList rootFolder
                 if(QOperatingSystemVersion::currentType() == QOperatingSystemVersion::OSType::MacOS)
                     parentFolderPath = parentFolderPath.normalized(QString::NormalizationForm::NormalizationForm_D);
 
+                parentFolderPath = QDir::toNativeSeparators(parentFolderPath);
+
                 if(!parentFolderPath.endsWith(QDir::separator()))
                     parentFolderPath.append(QDir::separator());
 
@@ -240,6 +242,8 @@ QJsonObject FileSystemMonitorService::generateFilesObject(QStringList rootFolder
 
                 if(QOperatingSystemVersion::currentType() == QOperatingSystemVersion::OSType::MacOS)
                     parentFolderPath = parentFolderPath.normalized(QString::NormalizationForm::NormalizationForm_D);
+
+                parentFolderPath = QDir::toNativeSeparators(parentFolderPath);
 
                 if(!parentFolderPath.endsWith(QDir::separator()))
                     parentFolderPath.append(QDir::separator());


### PR DESCRIPTION
Added missing path normalizations to server code for Windows in following parts:

- When renaming folder
- When relocating folder
- When detecting new folders 